### PR TITLE
[Build] Read metadata from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,13 @@ requires = [
     "Cython>=0.29.0,<3",
     "numpy>=1.19.5",
     "scipy>=1.2.1",
+    "tomli",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "LibRecommender"
-dynamic = ["version"]
+version = "0.12.6"
 description = "Versatile end-to-end recommender system."
 authors = [
     { name = "massquantity", email = "jinxin_madie@163.com" },
@@ -42,9 +43,6 @@ repository = "https://github.com/massquantity/LibRecommender"
 
 [tool.setuptools]
 include-package-data = true
-
-[tool.setuptools.dynamic]
-version = {attr = "libreco.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@ import logging
 import os
 import platform
 import sys
+from pathlib import Path
 
 import numpy as np
+import tomli
 from Cython.Build import cythonize
 from Cython.Distutils import build_ext
 from setuptools import Extension, find_packages, setup
@@ -90,10 +92,21 @@ extensions = [
     ),
 ]
 
+readme = (Path(__file__).parent / "README.md").read_text()
+toml_str = (Path(__file__).parent / "pyproject.toml").read_text()
+metadata = tomli.loads(toml_str)["project"]
 
 setup(
-    name="LibRecommender",
-    version="0.12.6",
+    name=metadata["name"],
+    version=metadata["version"],
+    description=metadata["description"],
+    author=metadata["authors"][0]["name"],
+    author_email=metadata["authors"][0]["email"],
+    license=metadata["license"]["text"],
+    url=metadata["urls"]["repository"],
+    long_description=readme,
+    classifiers=metadata["classifiers"],
+    keywords=metadata["keywords"],
     packages=find_packages(
         where=".",
         include=["libreco*", "libserving*"],


### PR DESCRIPTION
Python3.6 can't use `Setuptools` with `pyproject.toml` directly. Copy metadata to `setup.py`