### PR TITLE
[Dependency] TensorFlow & Protobuf incompatibility

### DIFF
--- a/.github/workflows/compatibility-tensorflow1.yml
+++ b/.github/workflows/compatibility-tensorflow1.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
+          python -m pip install 'protobuf<=3.20.2'
           python -m pip install $(sed "/tensorflow*/d;/nmslib*/d;/dgl*/d" requirements.txt)
           python -m pip install LibRecommender
           python -m pip install tensorflow==${{ matrix.tensorflow-version }}

--- a/.github/workflows/compatibility-tensorflow2.yml
+++ b/.github/workflows/compatibility-tensorflow2.yml
@@ -13,62 +13,62 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9]
-        tensorflow-version: [2.5.0, 2.8.0, 2.10.0]
+        tensorflow-version: [2.5.3, 2.8.4, 2.11.0]
         numpy-version: [1.20.3, 1.21.6, 1.22.4, 1.23.2]
         include:
           # Python 3.6 only supports Numpy 1.19.5
           - os: ubuntu-20.04
             python-version: '3.6'
-            tensorflow-version: 2.5.0
+            tensorflow-version: 2.5.3
             numpy-version: 1.19.5
           - os: windows-latest
             python-version: '3.6'
-            tensorflow-version: 2.5.0
+            tensorflow-version: 2.5.3
             numpy-version: 1.19.5
           - os: macos-latest
             python-version: '3.6'
-            tensorflow-version: 2.5.0
+            tensorflow-version: 2.5.3
             numpy-version: 1.19.5
 
           # TensorFlow 2.8 starts to support python 3.10
           - os: ubuntu-20.04
             python-version: '3.10'
-            tensorflow-version: 2.8.0
+            tensorflow-version: 2.8.4
             numpy-version: 1.22.4
           - os: windows-latest
             python-version: '3.10'
-            tensorflow-version: 2.8.0
+            tensorflow-version: 2.8.4
             numpy-version: 1.22.4
           - os: macos-latest
             python-version: '3.10'
-            tensorflow-version: 2.8.0
+            tensorflow-version: 2.8.4
             numpy-version: 1.22.4
 
-          # TensorFlow 2.10 with python 3.10 and different numpy versions
+          # TensorFlow 2.11 with python 3.10 and different numpy versions
           - os: ubuntu-20.04
             python-version: '3.10'
-            tensorflow-version: 2.10.0
+            tensorflow-version: 2.11.0
             numpy-version: 1.22.4
           - os: windows-latest
             python-version: '3.10'
-            tensorflow-version: 2.10.0
+            tensorflow-version: 2.11.0
             numpy-version: 1.22.4
           - os: macos-latest
             python-version: '3.10'
-            tensorflow-version: 2.10.0
+            tensorflow-version: 2.11.0
             numpy-version: 1.22.4
 
           - os: ubuntu-20.04
             python-version: '3.10'
-            tensorflow-version: 2.10.0
+            tensorflow-version: 2.11.0
             numpy-version: 1.23.2
           - os: windows-latest
             python-version: '3.10'
-            tensorflow-version: 2.10.0
+            tensorflow-version: 2.11.0
             numpy-version: 1.23.2
           - os: macos-latest
             python-version: '3.10'
-            tensorflow-version: 2.10.0
+            tensorflow-version: 2.11.0
             numpy-version: 1.23.2
 
     steps:
@@ -85,6 +85,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
+          python -m pip install 'protobuf<=3.20.2'
           python -m pip install $(sed "/tensorflow*/d;/nmslib*/d;/dgl*/d" requirements.txt)
           python -m pip install LibRecommender
           python -m pip install tensorflow==${{ matrix.tensorflow-version }}


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/releases/tag/v2.7.3

https://github.com/tensorflow/tensorflow/blob/v2.7.3/tensorflow/tools/pip_package/setup.py#L98

https://protobuf.dev/news/2022-05-06/#python-updates