### PR TITLE
[CI] Pin protobuf version

### DIFF
--- a/requirements-serving.txt
+++ b/requirements-serving.txt
@@ -6,3 +6,4 @@ aiohttp
 redis >= 4.2.0
 faiss-cpu == 1.7.2 ; python_version == "3.6"
 faiss-cpu >= 1.5.2 ; python_version > "3.6"
+protobuf < 4.24.0


### PR DESCRIPTION
We should be really careful about protobuf version when using `tf.saved_model`.