### PR TITLE
[Rust] Faster similarity computation

### DIFF
--- a/rust/src/similarities.rs
+++ b/rust/src/similarities.rs
@@ -4,31 +4,9 @@ use std::time::Instant;
 use fxhash::FxHashMap;
 use pyo3::PyResult;
 
-#[derive(Debug)]
-pub(crate) struct LabelSim(pub f32, pub f32);
+const MAX_BLOCK_SIZE: i64 = 200_000_000;
 
-impl Ord for LabelSim {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0
-            .partial_cmp(&other.0)
-            .unwrap_or(Ordering::Equal)
-    }
-}
-
-impl PartialOrd for LabelSim {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for LabelSim {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for LabelSim {}
-
+/// Divide `n_x` into several blocks to avoid huge memory consumption.
 pub(crate) fn invert_cosine(
     indices: &[i32],
     indptr: &[usize],
@@ -39,54 +17,65 @@ pub(crate) fn invert_cosine(
     n_y: usize,
     min_common: usize,
 ) -> PyResult<Vec<(i32, i32, f32)>> {
-    let mut start = Instant::now();
-    let n_x = i32::try_from(n_x)?;
-    for p in 0..n_y {
-        let x_start = indptr[p];
-        let x_end = indptr[p + 1];
-        for i in x_start..x_end {
-            for j in (i + 1)..x_end {
-                let x1 = indices[i];
-                let x2 = indices[j];
-                let key = x1 * n_x + x2;
-                let value = data[i] * data[j];
-                cum_values
-                    .entry(key)
-                    .and_modify(|(.., v, c)| {
-                        *v += value;
-                        *c += 1;
-                    })
-                    .or_insert((x1, x2, value, 1));
+    let start = Instant::now();
+    let mut cosine_sims: Vec<(i32, i32, f32)> = Vec::new();
+    let step = (MAX_BLOCK_SIZE as f64 / n_x as f64).ceil() as usize;
+    for block_start in (0..n_x).step_by(step) {
+        let block_end = std::cmp::min(block_start + step, n_x);
+        let block_size = block_end - block_start;
+        let mut prods = vec![0.0; block_size * n_x];
+        let mut counts = vec![0; block_size * n_x];
+        for p in 0..n_y {
+            let x_start = indptr[p];
+            let x_end = indptr[p + 1];
+            for i in x_start..x_end {
+                let x1 = usize::try_from(indices[i])?;
+                if x1 >= block_start && x1 < block_end {
+                    for j in (i + 1)..x_end {
+                        let x2 = usize::try_from(indices[j])?;
+                        let index = (x1 - block_start) * n_x + x2;
+                        let value = data[i] * data[j];
+                        prods[index] += value;
+                        counts[index] += 1;
+                        // cum_values
+                        //    .entry(key)
+                        //    .and_modify(|(.., v, c)| {
+                        //        *v += value;
+                        //        *c += 1;
+                        //    })
+                        //    .or_insert((x1, x2, value, 1));
+                    }
+                }
             }
         }
-        if p % 1000 == 0 {
-            let duration = start.elapsed();
-            println!("num {} elapsed: {:?}", p, duration);
-            start = Instant::now();
-        }
-    }
 
-    start = Instant::now();
-    let mut cosine_sims: Vec<(i32, i32, f32)> = Vec::new();
-    for &(x1, x2, prod, count) in cum_values.values() {
-        if count >= min_common {
-            let sq1 = sum_squares[usize::try_from(x1)?];
-            let sq2 = sum_squares[usize::try_from(x2)?];
-            if prod == 0.0 || sq1 == 0.0 || sq2 == 0.0 {
-                cosine_sims.push((x1, x2, 0.0));
-            } else {
-                let norm = sq1.sqrt() * sq2.sqrt();
-                let cosine = prod / norm;
-                cosine_sims.push((x1, x2, cosine));
+        for x1 in block_start..block_end {
+            for x2 in (x1 + 1)..n_x {
+                let index = (x1 - block_start) * n_x + x2;
+                let prod = prods[index];
+                let sq1 = sum_squares[x1];
+                let sq2 = sum_squares[x2];
+                let cosine = if prod == 0.0 || sq1 == 0.0 || sq2 == 0.0 {
+                    0.0
+                } else {
+                    let norm = sq1.sqrt() * sq2.sqrt();
+                    prod / norm
+                };
+                let key = i32::try_from(x1 * n_x + x2)?;
+                let x1 = i32::try_from(x1)?;
+                let x2 = i32::try_from(x2)?;
+                let count = counts[index];
+                if count >= min_common {
+                    cosine_sims.push((x1, x2, cosine));
+                }
+                if count > 0 {
+                    cum_values.insert(key, (x1, x2, cosine, count));
+                }
             }
         }
     }
     let duration = start.elapsed();
-    println!(
-        "cosine sim: {}, elapsed: {:?}",
-        cosine_sims.len(),
-        duration
-    );
+    println!("cosine sim: {} elapsed: {:.4?}", cosine_sims.len(), duration);
     Ok(cosine_sims)
 }
 
@@ -95,15 +84,13 @@ pub(crate) fn sort_by_sims(
     cosine_sims: Vec<(i32, i32, f32)>,
     sim_mapping: &mut FxHashMap<i32, (Vec<i32>, Vec<f32>)>,
 ) -> PyResult<()> {
-    let mut start = Instant::now();
+    let start = Instant::now();
     let mut agg_sims: Vec<Vec<(i32, f32)>> = vec![Vec::new(); n_x];
     for (x1, x2, sim) in cosine_sims {
         agg_sims[usize::try_from(x1)?].push((x2, sim));
         agg_sims[usize::try_from(x2)?].push((x1, sim));
     }
-    let duration = start.elapsed();
-    println!("agg elapsed: {:?}", duration);
-    start = Instant::now();
+
     for (i, neighbor_sims) in agg_sims.iter_mut().enumerate() {
         if neighbor_sims.is_empty() {
             continue;
@@ -116,9 +103,35 @@ pub(crate) fn sort_by_sims(
         sim_mapping.insert(i32::try_from(i)?, (neighbors, sims));
     }
     let duration = start.elapsed();
-    println!("sort elapsed: {:?}", duration);
+    println!("sort elapsed: {:.4?}", duration);
     Ok(())
 }
+
+/// 0: sim, 1: label
+#[derive(Debug)]
+pub(crate) struct SimOrd(pub f32, pub f32);
+
+impl Ord for SimOrd {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0
+            .partial_cmp(&other.0)
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for SimOrd {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for SimOrd {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for SimOrd {}
 
 #[cfg(test)]
 mod tests {
@@ -128,16 +141,16 @@ mod tests {
     #[test]
     fn test_sim_max_heap() {
         let mut heap = BinaryHeap::new();
-        heap.push(LabelSim(1.1, 1.1));
-        heap.push(LabelSim(0.0, 1.1));
-        heap.push(LabelSim(-2.0, 0.0));
-        heap.push(LabelSim(-0.2, 3.3));
-        heap.push(LabelSim(8.8, 8.8));
-        assert_eq!(heap.pop(), Some(LabelSim(8.8, 8.8)));
-        assert_eq!(heap.pop(), Some(LabelSim(1.1, 1.1)));
-        assert_eq!(heap.pop(), Some(LabelSim(0.0, 1.1)));
-        assert_eq!(heap.pop(), Some(LabelSim(-0.2, 3.3)));
-        assert_eq!(heap.pop(), Some(LabelSim(-2.0, 0.0)));
+        heap.push(SimOrd(1.1, 1.1));
+        heap.push(SimOrd(0.0, 1.1));
+        heap.push(SimOrd(-2.0, 0.0));
+        heap.push(SimOrd(-0.2, 3.3));
+        heap.push(SimOrd(8.8, 8.8));
+        assert_eq!(heap.pop(), Some(SimOrd(8.8, 8.8)));
+        assert_eq!(heap.pop(), Some(SimOrd(1.1, 1.1)));
+        assert_eq!(heap.pop(), Some(SimOrd(0.0, 1.1)));
+        assert_eq!(heap.pop(), Some(SimOrd(-0.2, 3.3)));
+        assert_eq!(heap.pop(), Some(SimOrd(-2.0, 0.0)));
         assert_eq!(heap.pop(), None);
     }
 }

--- a/rust/src/user_cf.rs
+++ b/rust/src/user_cf.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::*;
 use rand::seq::SliceRandom;
 
-use crate::similarities::{invert_cosine, sort_by_sims, LabelSim};
+use crate::similarities::{invert_cosine, sort_by_sims, SimOrd};
 
 // todo: user_consumed, sparse struct, PyUserCF
 #[pyclass]
@@ -95,7 +95,7 @@ impl UserCF {
             if let Some((sim_users, sim_values)) = self.sim_mapping.get(u) {
                 let i_start = indptr[*i];
                 let i_end = indptr[*i + 1];
-                let mut max_heap: BinaryHeap<LabelSim> = BinaryHeap::new();
+                let mut max_heap: BinaryHeap<SimOrd> = BinaryHeap::new();
                 // todo: sim_users[..self.k_sim]
                 for (&su, &sv) in sim_users.iter().zip(sim_values.iter()) {
                     for (&iu, &iv) in indices[i_start..i_end]
@@ -103,7 +103,7 @@ impl UserCF {
                         .zip(data[i_start..i_end].iter())
                     {
                         if su == iu {
-                            max_heap.push(LabelSim(sv, iv))
+                            max_heap.push(SimOrd(sv, iv))
                         }
                     }
                 }
@@ -115,7 +115,7 @@ impl UserCF {
                 let mut k_neighbor_sims = Vec::new();
                 let mut k_neighbor_labels = Vec::new();
                 for _ in 0..self.k_sim {
-                    if let Some(LabelSim(sim, label)) = max_heap.pop() {
+                    if let Some(SimOrd(sim, label)) = max_heap.pop() {
                         k_neighbor_sims.push(sim);
                         k_neighbor_labels.push(label);
                     } else {


### PR DESCRIPTION
Replace HashMap with array, since hashing is extremely slow even with a faster hash function.